### PR TITLE
Fix:  Bug Solosprint Trigger Box

### DIFF
--- a/scene/src/solo-sprint-2/scene.main.ts
+++ b/scene/src/solo-sprint-2/scene.main.ts
@@ -602,7 +602,7 @@ export class SoloSprint {
         rotation: Quaternion.fromEulerDegrees(0.0, 270.0, 0.0)
       },
 
-      // 4 - door.single.002 
+      // 4 - door.single.002
       {
         position: Vector3.create(32.057, 11.857, 2),
         rotation: Quaternion.fromEulerDegrees(0.0, 270.0, 0.0)


### PR DESCRIPTION
In this PR you can find the correction of a minor Bug on Solo Sprint Instance

-Door´s Triggerbox was out of boundaries